### PR TITLE
Edwin slave test

### DIFF
--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -18,3 +18,8 @@
 #
 
 include_recipe "rs-mysql::volume"
+
+#remove auto.conf if exists in backup. causes isssues with same UUIDs
+file "#{node['rs-mysql']['device']['mount_point']}/auto.conf" do
+  action :delete
+end

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -22,4 +22,5 @@ include_recipe "rs-mysql::volume"
 #remove auto.conf if exists in backup. causes isssues with same UUIDs
 file "#{node['rs-mysql']['device']['mount_point']}/auto.conf" do
   action :delete
+  only_if do ::File.exists?("#{node['rs-mysql']['device']['mount_point']}/auto.conf") end
 end


### PR DESCRIPTION
When using mysql 5.6+ / percona 5.6+ , we need to remove the auto.conf file that is included in /var/lib/mysql/ . It contains the masters UUID and if it exists the slave attempts to use the file and the UUID in the file, which causes a conflict 

Fatal error: The slave I/O thread stops because master and slave have equal MySQL server UUIDs; these UUIDs must be different for replication to work.
